### PR TITLE
alternate header with year and code camp number included in svg

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,3 +37,4 @@ It also runs a local webserver and makes the site available at
 * [11ty - Config Input Directory](https://www.11ty.io/docs/config/#input-directory)
 * [11ty - JS Templates](https://www.11ty.io/docs/languages/javascript/)
 * [a11y - add lang attribute](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse)
+* [a11y - Accessible SVGs](https://css-tricks.com/accessible-svgs/)

--- a/src/_includes/page-layout.njk
+++ b/src/_includes/page-layout.njk
@@ -22,14 +22,10 @@
 <body>
     <header class="page">
         <div class="inner">
-            <h1>
-                <a href="/">
-                    <img src="/images/vermont-code-camp-logo-400x66.png" width="400" height="66" alt="Vermont Code Camp" id="vermont-code-camp-logo" title="Vermont Code Camp homepage" />
+            <h1 >
+                <a class="header-logo" href="/">
+                    {% include "vermont-code-camp-logo-2017.svg" %}
                 </a>
-                <div class="year-container">
-                    <span class="annual-number">9</span>
-                    <span class="year">2017</span>
-                </div>
             </h1>
         </div>
     </header>

--- a/src/_includes/vermont-code-camp-logo-2017.svg
+++ b/src/_includes/vermont-code-camp-logo-2017.svg
@@ -1,0 +1,126 @@
+<svg viewBox="0 0 560 80" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.4" role="img" aria-labelledby="header-logo">
+  <title id="header-logo">2017 Vermont Code Camp 9</title>
+  <path d="M132.9 7.8h6.3l4.6 14.6 4.6-14.6h6.3l-7.6 21.3h-6.4l-7.8-21.3z" fill="url(#_Linear1)" fill-rule="nonzero"/>
+  <path d="M223.5 7.8h10.6c2.4 0 4.3.7 5.9 2.1 1.5 1.4 2.3 3 2.3 5.1a6 6 0 0 1-.4 2.4 7.7 7.7 0 0 1-2.1 3l-.9.7-.7.4 5 7.6h-6.4l-4.3-6.5h-2.8v6.5h-6.1V7.8h-.1zm6.1 5v4.9h4.7c1.2 0 2.5-.8 2.5-2.5 0-1.4-1.4-2.4-2.5-2.4h-4.7z" fill="url(#_Linear2)" fill-rule="nonzero"/>
+  <path d="M386.4 7.8v21.3h-5.2l-9-11.8v11.8h-5.8V7.8h5l8.9 11.7V7.8h6.1z" fill="url(#_Linear3)" fill-rule="nonzero"/>
+  <path d="M430.5 7.8v5.4h-6.1v15.9h-6V13.2h-6.1V7.8h18.2z" fill="url(#_Linear4)" fill-rule="nonzero"/>
+  <path d="M274 16.5v12.6h-5.7V7.8h5.9l5.5 8.4 5.3-8.4h6v21.3h-5.8V16.5l-5.5 8.4-5.7-8.4z" fill="url(#_Linear5)" fill-rule="nonzero"/>
+  <path d="M336.6 26.4a11 11 0 0 1-8 3.3 11 11 0 0 1-8-3.3 10.7 10.7 0 0 1-3.3-7.8c0-3 1.1-5.6 3.3-7.8a11 11 0 0 1 8-3.3c3.2 0 5.8 1.1 8 3.3 2.2 2.2 3.3 4.8 3.3 7.8s-1.1 5.6-3.3 7.8zm-11.9-3.7a5.4 5.4 0 0 0 4 1.7 5.7 5.7 0 0 0 5.6-6.1c0-3.1-2.5-5.7-5.6-5.7a5.7 5.7 0 0 0-5.6 5.9c0 1.7.5 3.1 1.6 4.2z" fill="url(#_Linear6)" fill-rule="nonzero"/>
+  <path d="M197.3 24.2v4.9h-16.9V7.8h16.9v4.9h-11.1V16h9.9v4.6h-9.9v3.6h11.1z" fill="url(#_Linear7)" fill-rule="nonzero"/>
+  <path d="M137.1 61.4c1.8 1.9 3.4 2.5 6.1 2.5a9 9 0 0 0 4.3-1c1.5-.8 2.6-1.5 3.3-2.3l1-1.1 6.3 5.7a22 22 0 0 1-5.2 4.7 19.7 19.7 0 0 1-9.4 2.7c-5.2 0-9.5-1.1-13.2-4.8a18.3 18.3 0 0 1-5.4-13.2c0-5.1 1.8-9.5 5.4-13.2 3.6-3.7 8.1-5.5 13.3-5.5 3.2 0 6.4.8 9.1 2.5 1.1.7 1.9 1.4 2.7 2.2a18 18 0 0 1 2.6 3l-6.5 5.4-1.5-1.6c-.6-.5-1.1-1-1.8-1.4a9 9 0 0 0-4.7-1.6c-2.8 0-5 1-6.9 2.9-1.8 1.9-2.4 4.2-2.4 7.2.3 2.9 1.1 5 2.9 6.9z" fill="url(#_Linear8)" fill-rule="nonzero"/>
+  <path d="M192.5 67a17.7 17.7 0 0 1-13.1 5.4c-5.1 0-9.5-1.8-13.1-5.4-3.5-3.4-5.5-8-5.4-12.9 0-5 1.8-9.3 5.4-12.9 3.6-3.6 7.9-5.4 13.1-5.4 5.1 0 9.5 1.8 13.1 5.4 3.6 3.6 5.4 7.9 5.4 12.9s-1.8 9.3-5.4 12.9zM173 60.9a8.7 8.7 0 0 0 6.5 2.8c2.6 0 4.7-.9 6.5-2.8a9.7 9.7 0 0 0 2.6-6.9c0-2.8-.9-5.1-2.6-6.9a8.6 8.6 0 0 0-6.5-2.7c-2.6 0-4.7.9-6.5 2.7a9.7 9.7 0 0 0-2.6 6.9c0 2.7.8 5 2.6 6.9z" fill="url(#_Linear9)" fill-rule="nonzero"/>
+  <path d="M217 36.5c5.4 0 10.6 1.7 14.2 5.1a17 17 0 0 1 5.3 12.6c0 5-1.8 9.2-5.3 12.6a20.5 20.5 0 0 1-14.2 5.1h-13.6V36.5H217zm-4 8.6v18.1h4c2.5 0 5.2-.9 7-2.6a8.6 8.6 0 0 0 2.7-6.5c0-2.7-.8-4.8-2.5-6.5a10.3 10.3 0 0 0-7.1-2.5H213z" fill="url(#_Linear10)" fill-rule="nonzero"/>
+  <path d="M269.5 63.7v8.1h-27.9V36.5h27.9v8.1h-18.3v5.5h16.4v7.6h-16.4v6h18.3z" fill="url(#_Linear11)" fill-rule="nonzero"/>
+  <path d="M335.5 65.2l-2.7 6.6h-10.3l14.1-35.3h10.6l14 35.3h-10.3l-2.7-6.6h-12.7zm6.3-18.9l-3.7 11.4h7.3l-3.6-11.4z" fill="url(#_Linear12)" fill-rule="nonzero"/>
+  <path d="M374 50.9v20.9h-9.5V36.5h9.9l9 14 8.8-14h9.9v35.3h-9.7V50.9l-9.2 13.9-9.2-13.9z" fill="url(#_Linear13)" fill-rule="nonzero"/>
+  <path d="M424.7 36.5c3.9 0 7 1.2 9.5 3.5 2.4 2.3 3.6 5.3 3.6 8.8 0 3.6-1.2 6.5-3.7 8.9a13.3 13.3 0 0 1-9.4 3.7h-6.6v10.4h-9.7V36.5h16.3zm-6.6 8.3v9h6.1c1.8 0 4.2-1.4 4.2-4.5 0-2.5-2.5-4.5-4.2-4.5h-6.1z" fill="url(#_Linear14)" fill-rule="nonzero"/>
+  <path d="M299.7 61.4c1.8 1.9 3.4 2.5 6.1 2.5a9 9 0 0 0 4.3-1c1.5-.8 2.6-1.5 3.3-2.3l1-1.1 6.3 5.7-.5.8a22 22 0 0 1-4.6 3.9 19.7 19.7 0 0 1-9.4 2.7c-5.2 0-9.5-1.1-13.2-4.8a18.3 18.3 0 0 1-5.4-13.2c0-5.1 1.8-9.5 5.4-13.2 3.6-3.7 8.1-5.5 13.3-5.5 3.2 0 6.4.8 9.1 2.5 1.1.7 1.9 1.4 2.7 2.2a18 18 0 0 1 2.6 3l-6.5 5.4-1.5-1.6c-.6-.5-1.1-1-1.8-1.4a9 9 0 0 0-4.7-1.6c-2.8 0-5 1-6.9 2.9-1.8 1.9-2.4 4.2-2.4 7.2.1 2.9.9 5 2.8 6.9z" fill="url(#_Linear15)" fill-rule="nonzero"/>
+  <path d="M80 36l31.6-13.2v5.1L84.5 39.7l27.1 11.1v5L80 42.9V36zm400 6.7l-31.6 12.9v-5l27.1-11.1-27.1-11.8v-5.1L480 35.9v6.8z" fill="#bababa" fill-rule="nonzero"/>
+  <path d="M517.7 61.9a21 21 0 0 1-13.8-5l4.9-7c3 2.4 6 3.6 9.2 3.6 5 0 7.8-3.2 8.5-9.6-2.2 2-5 3-8.5 3-4.6 0-8.3-1.3-11-3.7-2.7-2.4-4-5.8-4-10 0-4.3 1.4-7.8 4.4-10.6 3-2.8 6.9-4.2 11.6-4.2 5 0 9 1.5 12.1 4.6 3.3 3.3 5 8.6 5 16 0 7-1.6 12.4-4.7 16.5a16.3 16.3 0 0 1-13.7 6.4zm1.8-22.8c2.2 0 4-.6 5.3-1.8a6 6 0 0 0 1.9-4.5 6 6 0 0 0-2-4.7 7.7 7.7 0 0 0-5.4-1.8c-2.3 0-4 .6-5.3 1.8a6.1 6.1 0 0 0-1.9 4.7c0 2 .7 3.4 2 4.6a7.8 7.8 0 0 0 5.4 1.7z" fill="url(#_Linear16)" fill-rule="nonzero"/>
+  <path d="M23 30l6.1-5c1.2-1 2-1.8 2.5-2.4.4-.6.7-1.3.7-2 0-.8-.2-1.4-.7-1.8-.4-.4-1-.6-1.8-.6-.6 0-1.3.2-1.8.6-.5.4-1.2 1-1.9 1.9l-2.8-2.3c1-1.3 2-2.2 2.9-2.8 1-.7 2.4-1 4-1 1.8 0 3.3.5 4.5 1.6 1.1 1 1.7 2.4 1.7 4a6 6 0 0 1-1.2 3.8c-.6.8-1.8 2-3.6 3.3l-3 2.3h8v3.5H23v-3.2z" fill="url(#_Linear17)" fill-rule="nonzero"/>
+  <path d="M48.8 33.4c-2.4 0-4.4-1-5.9-2.7-1.4-1.8-2.2-4-2.2-6.7s.8-5 2.3-6.7a7.3 7.3 0 0 1 5.8-2.7c2.4 0 4.3.9 5.9 2.7a10 10 0 0 1 2.2 6.7c0 2.7-.8 4.9-2.2 6.7a7.3 7.3 0 0 1-6 2.7zm0-3.6c1.2 0 2.2-.6 3-1.7.6-1 1-2.4 1-4.1 0-1.7-.4-3-1.1-4.2-.8-1-1.7-1.6-3-1.6-1.1 0-2 .5-2.8 1.6-.7 1.1-1 2.5-1 4.2 0 1.7.3 3 1 4.1a3.4 3.4 0 0 0 3 1.7z" fill="url(#_Linear18)" fill-rule="nonzero"/>
+  <path d="M29 45.4l-4.4 1.1-1.2-4.5 7.3-2.2h3.7v25.4H29V45.4z" fill="url(#_Linear19)" fill-rule="nonzero"/>
+  <path d="M50.2 44.8H38.4V40h18.1v4.2l-11.3 21H39l11.2-20.4z" fill="url(#_Linear20)" fill-rule="nonzero"/>
+  <defs>
+    <linearGradient id="_Linear1" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 -21.3 21.3 0 143.7 29.1)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear2" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 -21.3 21.3 0 233.3 29.1)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear3" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 -21.3 21.3 0 376.4 29.1)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear4" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 -21.3 21.3 0 421.5 29.1)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear5" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 -21.3 21.3 0 279.6 29.1)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear6" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 -22.1 22.1 0 328.6 29.7)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear7" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="rotate(-90 109 -79.9) scale(21.3)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear8" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="rotate(-90 107 -34.6) scale(36.6)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear9" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="rotate(-90 126 -53.5) scale(36.6)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear10" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 -35.3 35.3 0 220 71.8)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear11" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 -35.3 35.3 0 255.5 71.8)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear12" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 -35.3 35.3 0 341.8 71.8)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear13" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 -35.3 35.3 0 383.3 71.8)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear14" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 -35.3 35.3 0 423.1 71.8)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear15" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 -36.6 36.6 0 304.2 72.4)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear16" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="rotate(-90 290.1 -229.5) scale(41.3725)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear17" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="rotate(-90 26 6.7) scale(19.3747)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear18" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="rotate(-90 26 6.7) scale(19.3747)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear19" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="rotate(-90 52.7 11.7) scale(23.0699)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+    <linearGradient id="_Linear20" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="rotate(-90 52.7 11.7) scale(23.0699)">
+      <stop offset="0" stop-color="#d1d1d1"/>
+      <stop offset=".5" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -88,7 +88,7 @@ aside.page ol.list-inline li {
 
 header.page {
     position: relative;
-    padding-bottom: 10px;
+    padding: 16px 2%;
     background-color: #1595D3;
     background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(transparent), to(rgba(0, 0, 0, 0.2)));
     background-image: -webkit-linear-gradient(top, transparent, rgba(0, 0, 0, 0.2));
@@ -104,26 +104,16 @@ header.page {
 header a:hover {
     text-decoration: none;
 }
-header .year-container {
-    position: relative;
-    max-width: 400px;
+.header-logo {
+    display: block;
+    width: 570px;
+    max-width: 100%;
     margin: 0 auto;
 }
-header .annual-number {
-    font-size: 5rem;
-    color: #014C72;
-    text-shadow: 0 0 20px #FFFFFF4D;
-    display: inline-block;
-    position: absolute;
-    top: -30px;
-    left: 33%;
+.header-logo svg {
+    display: block;
 }
-header .year {
-    font-size: 2.4rem;
-    color: #81bfde;
-    display: inline-block;
-    margin: 0 0 0 8rem;
-}
+
 header.page nav {
     width: 96%;
     display: inline-block;
@@ -615,7 +605,7 @@ article.resource p {
 
 
 
-svg {
+.list-inline svg, .twitter svg {
     width: 15px;
     height: 15px;
 }


### PR DESCRIPTION
I felt like the header could be cleaner.  What do you think?

This PR:
<img width="612" alt="Screen Shot 2019-05-11 at 3 13 13 PM" src="https://user-images.githubusercontent.com/281482/57574022-67646c00-73ff-11e9-9f39-fcdb7ea91021.png">

Previously:
<img width="640" alt="Screen Shot 2019-05-11 at 3 13 29 PM" src="https://user-images.githubusercontent.com/281482/57574023-69c6c600-73ff-11e9-88c5-f7df20a620b5.png">

 I was originally trying to insert the year and annual number as html elements, but I was finding it quite difficult to keep the text proportional to the logo image as the viewport size changed.  So I modified the image to include the year and annual number. 